### PR TITLE
Fix: Render MCP tool output identically to built-in tools

### DIFF
--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1473,10 +1473,8 @@ async function checkPermissionsAndCallTool(
       })
     }
 
-    // TOOD(hackyon): refactor so we don't have different experiences for MCP tools
-    if (!isMcpTool(tool)) {
-      await addToolResult(toolOutput, mappedToolResultBlock)
-    }
+    // All tools get the same rendering path — no MCP/built-in bifurcation
+    await addToolResult(toolOutput, mappedToolResultBlock)
 
     const postToolHookInfos: StopHookInfo[] = []
     const postToolHookStart = Date.now()
@@ -1535,10 +1533,6 @@ async function checkPermissionsAndCallTool(
         `Slow PostToolUse hooks: ${postToolHookDurationMs}ms for ${tool.name} (${postToolHookInfos.length} hooks)`,
         { level: 'info' },
       )
-    }
-
-    if (isMcpTool(tool)) {
-      await addToolResult(toolOutput)
     }
 
     // Show PostToolUse hook timing inline below tool result when > 500ms.

--- a/src/tools/MCPTool/MCPTool.ts
+++ b/src/tools/MCPTool/MCPTool.ts
@@ -15,7 +15,7 @@ export const inputSchema = lazySchema(() => z.object({}).passthrough())
 type InputSchema = ReturnType<typeof inputSchema>
 
 export const outputSchema = lazySchema(() =>
-  z.string().describe('MCP tool execution result'),
+  z.any().describe('MCP tool execution result'),
 )
 type OutputSchema = ReturnType<typeof outputSchema>
 


### PR DESCRIPTION
## Problem

MCP tool results are invisible to users. When Claude calls an MCP tool, the model receives the response, but users see no output block. Built-in tools (Bash, Edit, Read) display output normally.

This affects **all** MCP servers — plugins, project `.mcp.json`, everything.

## Root Cause

Two gates in the rendering pipeline prevent MCP tool output from reaching users:

### Gate 1: `toolExecution.ts` — separate code paths

```typescript
// TOOD(hackyon): refactor so we don't have different experiences for MCP tools
if (!isMcpTool(tool)) {
  await addToolResult(toolOutput, mappedToolResultBlock)
}
```

`addToolResult()` stores tool results for UI rendering. It was only called for built-in tools. MCP tools were routed through a separate path that called `addToolResult()` later, without the pre-mapped block. The upstream dev left a typo'd TODO acknowledging this.

### Gate 2: `MCPTool.ts` — outputSchema type mismatch

```typescript
export const outputSchema = lazySchema(() =>
  z.string().describe("MCP tool execution result"),
)
```

MCP tool results arrive as content arrays (objects), not strings. `UserToolSuccessMessage` validates results against `outputSchema` before rendering — `z.string().safeParse()` on an array fails silently, returning `null`. The renderer never fires.

## Fix

**toolExecution.ts**: Remove the `isMcpTool` guard. All tools call `addToolResult()` through the same path. Remove the duplicate MCP-only `addToolResult()` call downstream.

**MCPTool.ts**: Change `outputSchema` from `z.string()` to `z.any()` so validation accepts whatever the MCP server returns.

## Result

MCP tool output renders in the same result block as built-in tools. Same component (`OutputLine`), same pipeline, same user experience.

Net change: +3 lines, -9 lines.
